### PR TITLE
CI: Update KF5 and use Qt's OpenSSL binaries on Windows.

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -11,10 +11,14 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { kf5_version: "5.104", kf5_fullver: "5.104.0", qt_version: "5.15.2",
-              qt_modules: "", kf5_cmake_args: "" }
-          - { kf5_version: "5.104", kf5_fullver: "5.104.0", qt_version: "6.5.0",
-              qt_modules: "qt5compat", kf5_cmake_args: "-DBUILD_WITH_QT6=ON" }
+          - kf5_version: "5.106"
+            kf5_fullver: "5.106.0"
+            qt_version: "5.15.2"
+            kf5_cmake_args: ""
+          - kf5_version: "5.106"
+            kf5_fullver: "5.106.0"
+            qt_version: "6.5.0"
+            kf5_cmake_args: "-DBUILD_WITH_QT6=ON"
 
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +29,6 @@ jobs:
         with:
           arch: clang_64
           version: ${{ matrix.cfg.qt_version }}
-          modules: ${{ matrix.cfg.qt_modules }}
       - name: Build Qt Libs
         env:
           MACOSX_DEPLOYMENT_TARGET: "11.0"

--- a/.github/workflows/win-ci.yml
+++ b/.github/workflows/win-ci.yml
@@ -11,12 +11,22 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { kf5_version: "5.104", kf5_fullver: "5.104.0", qt_version: "5.15.2",
-              qt_modules: "", cmake_generator: "Visual Studio 16 2019",
-              kf5_cmake_args: "", build_installer: "$false" }
-          - { kf5_version: "5.104", kf5_fullver: "5.104.0", qt_version: "6.4.3",
-              qt_modules: "qt5compat", cmake_generator: "Visual Studio 16 2019",
-              kf5_cmake_args: "-DBUILD_WITH_QT6=ON", build_installer: "$true" }
+          - kf5_version: "5.106"
+            kf5_fullver: "5.106.0"
+            qt_version: "5.15.2"
+            qt_ssl_suffix: ""
+            ssl_lib_suffix: "1_1"
+            cmake_generator: "Visual Studio 16 2019"
+            kf5_cmake_args: ""
+            build_installer: "$false"
+          - kf5_version: "5.106"
+            kf5_fullver: "5.106.0"
+            qt_version: "6.4.3"
+            qt_ssl_suffix: "v3"
+            ssl_lib_suffix: "3"
+            cmake_generator: "Visual Studio 16 2019"
+            kf5_cmake_args: "-DBUILD_WITH_QT6=ON"
+            build_installer: "$true"
 
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +37,7 @@ jobs:
         with:
           arch: win64_msvc2019_64
           version: ${{ matrix.cfg.qt_version }}
-          modules: ${{ matrix.cfg.qt_modules }}
+          tools: tools_openssl${{ matrix.cfg.qt_ssl_suffix }}_x64
       - name: Build Qt Libs
         run: |
           mkdir build_deps
@@ -77,10 +87,10 @@ jobs:
               qtextpad-win64\data
           windeployqt qtextpad-win64\KF5SyntaxHighlighting.dll --release --no-opengl-sw
 
-          # TODO: Use the Qt versions of the OpenSSL libs.  Depends on
-          # https://github.com/jurplel/install-qt-action/issues/16
-          cmake -E copy "C:\Program Files\OpenSSL\bin\libcrypto-1_1-x64.dll" `
-              "C:\Program Files\OpenSSL\bin\libssl-1_1-x64.dll" `
+          # Deploy OpenSSL libs for the online repository update
+          cmake -E copy `
+              "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL${{ matrix.cfg.qt_ssl_suffix }}\Win_x64\bin\libcrypto-${{ matrix.cfg.ssl_lib_suffix }}-x64.dll" `
+              "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL${{ matrix.cfg.qt_ssl_suffix }}\Win_x64\bin\libssl-${{ matrix.cfg.ssl_lib_suffix }}-x64.dll" `
               qtextpad-win64
 
           cmake -E tar cf "..\qtextpad-win64-${buildver}.zip" --format=zip qtextpad-win64

--- a/.github/workflows/win-ci.yml
+++ b/.github/workflows/win-ci.yml
@@ -14,19 +14,19 @@ jobs:
           - kf5_version: "5.106"
             kf5_fullver: "5.106.0"
             qt_version: "5.15.2"
-            qt_ssl_suffix: ""
-            ssl_lib_suffix: "1_1"
+            qt_tools: "tools_openssl_x64"
             cmake_generator: "Visual Studio 16 2019"
             kf5_cmake_args: ""
             build_installer: "$false"
+            deploy_openssl: "$true"
           - kf5_version: "5.106"
             kf5_fullver: "5.106.0"
             qt_version: "6.4.3"
-            qt_ssl_suffix: "v3"
-            ssl_lib_suffix: "3"
+            qt_tools: ""
             cmake_generator: "Visual Studio 16 2019"
             kf5_cmake_args: "-DBUILD_WITH_QT6=ON"
             build_installer: "$true"
+            deploy_openssl: "$false"
 
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
         with:
           arch: win64_msvc2019_64
           version: ${{ matrix.cfg.qt_version }}
-          tools: tools_openssl${{ matrix.cfg.qt_ssl_suffix }}_x64
+          tools: ${{ matrix.cfg.qt_tools }}
       - name: Build Qt Libs
         run: |
           mkdir build_deps
@@ -87,11 +87,16 @@ jobs:
               qtextpad-win64\data
           windeployqt qtextpad-win64\KF5SyntaxHighlighting.dll --release --no-opengl-sw
 
-          # Deploy OpenSSL libs for the online repository update
-          cmake -E copy `
-              "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL${{ matrix.cfg.qt_ssl_suffix }}\Win_x64\bin\libcrypto-${{ matrix.cfg.ssl_lib_suffix }}-x64.dll" `
-              "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL${{ matrix.cfg.qt_ssl_suffix }}\Win_x64\bin\libssl-${{ matrix.cfg.ssl_lib_suffix }}-x64.dll" `
-              qtextpad-win64
+          # OpenSSL libs are required for the online repository update in Qt5,
+          # but Qt6 can use the Windows SChannel backend instead
+          if (${{ matrix.cfg.deploy_openssl }}) {
+              cmake -E copy `
+                  "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL\Win_x64\bin\libcrypto-1_1-x64.dll" `
+                  "${Env:RUNNER_WORKSPACE}\Qt\Tools\OpenSSL\Win_x64\bin\libssl-1_1-x64.dll" `
+                  qtextpad-win64
+          } else {
+              cmake -E rm qtextpad-win64\tls\qopensslbackend.dll
+          }
 
           cmake -E tar cf "..\qtextpad-win64-${buildver}.zip" --format=zip qtextpad-win64
           cd ..\win32

--- a/win32/setup.iss
+++ b/win32/setup.iss
@@ -21,8 +21,8 @@ Source: qtextpad-win64\vc_redist.x64.exe; DestDir: {tmp}; Flags: deleteafterinst
 Source: qtextpad-win64\COPYING; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\qtextpad.exe; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\KF5SyntaxHighlighting.dll; DestDir: {app}; Flags: ignoreversion
-Source: qtextpad-win64\libcrypto-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
-Source: qtextpad-win64\libssl-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: qtextpad-win64\libcrypto-3-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: qtextpad-win64\libssl-3-x64.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Core.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Gui.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Network.dll; DestDir: {app}; Flags: ignoreversion
@@ -162,11 +162,13 @@ Filename: {tmp}\vc_redist.x64.exe; Parameters: /q /norestart
 
 [InstallDelete]
 Name: {app}\magic.mgc; Type: files
+Name: {app}\libcrypto-1_1-x64.dll; Type: files
 Name: {app}\libgcc_s_seh-1.dll; Type: files
 Name: {app}\libiconv-2.dll; Type: files
 Name: {app}\libintl-8.dll; Type: files
 Name: {app}\libKF5SyntaxHighlighting.dll; Type: files
 Name: {app}\libmagic-1.dll; Type: files
+Name: {app}\libssl-1_1-x64.dll; Type: files
 Name: {app}\libstdc++-6.dll; Type: files
 Name: {app}\libsystre-0.dll; Type: files
 Name: {app}\libtre-5.dll; Type: files

--- a/win32/setup.iss
+++ b/win32/setup.iss
@@ -21,8 +21,6 @@ Source: qtextpad-win64\vc_redist.x64.exe; DestDir: {tmp}; Flags: deleteafterinst
 Source: qtextpad-win64\COPYING; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\qtextpad.exe; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\KF5SyntaxHighlighting.dll; DestDir: {app}; Flags: ignoreversion
-Source: qtextpad-win64\libcrypto-3-x64.dll; DestDir: {app}; Flags: ignoreversion
-Source: qtextpad-win64\libssl-3-x64.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Core.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Gui.dll; DestDir: {app}; Flags: ignoreversion
 Source: qtextpad-win64\Qt6Network.dll; DestDir: {app}; Flags: ignoreversion
@@ -38,7 +36,6 @@ Source: qtextpad-win64\networkinformation\qnetworklistmanager.dll; DestDir: {app
 Source: qtextpad-win64\platforms\qwindows.dll; DestDir: {app}\platforms; Flags: ignoreversion
 Source: qtextpad-win64\styles\qwindowsvistastyle.dll; DestDir: {app}\styles; Flags: ignoreversion
 Source: qtextpad-win64\tls\qcertonlybackend.dll; DestDir: {app}\tls; Flags: ignoreversion
-Source: qtextpad-win64\tls\qopensslbackend.dll; DestDir: {app}\tls; Flags: ignoreversion
 Source: qtextpad-win64\tls\qschannelbackend.dll; DestDir: {app}\tls; Flags: ignoreversion
 Source: qtextpad-win64\translations\qt_ar.qm; DestDir: {app}\translations; Flags: ignoreversion
 Source: qtextpad-win64\translations\qt_bg.qm; DestDir: {app}\translations; Flags: ignoreversion
@@ -188,6 +185,7 @@ Name: {app}\imageformats\qwbmp.dll; Type: files
 Name: {app}\imageformats\qwebp.dll; Type: files
 Name: {app}\printsupport\windowsprintersupport.dll; Type: files
 Name: {app}\printsupport; Type: dirifempty
+Name: {app}\tls\qopensslbackend.dll; Type: files
 Name: {app}\data\qlogging-categories5\ksyntaxhighlighting.categories; Type: files
 Name: {app}\data\qlogging-categories5\org_kde_ksyntaxhighlighting.categories; Type: files
 Name: {app}\data\qlogging-categories5; Type: dirifempty


### PR DESCRIPTION
This also removes the no-longer necessary `qt5compat` module from the Qt installations